### PR TITLE
Make building Java CC without OpenJML possible

### DIFF
--- a/smart-contract/hyperledger-fabric/v2/java/.gitignore
+++ b/smart-contract/hyperledger-fabric/v2/java/.gitignore
@@ -9,13 +9,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
-*.iws
-*.iml
-*.ipr
+.idea/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/smart-contract/hyperledger-fabric/v2/java/README.md
+++ b/smart-contract/hyperledger-fabric/v2/java/README.md
@@ -15,6 +15,16 @@ However, note that normally, you do not need to locally build the chaincode.
 The [test network](../../../../test-network/README.adoc) will build generate this JAR as part of a [dockerized](https://www.docker.com/) build process.
 Build directly only if you know what you are doing.
 
+## Development
+
+You most likely do not want to build with OpenJML for local development, eg in your IDE.
+To disable OpenJML, simply set the `withoutOpenJML` Gradle property to `true`.
+For example, in `gradle.properties`:
+
+```properties
+withoutOpenJML = "true"
+```
+
 
 ## License
 

--- a/smart-contract/hyperledger-fabric/v2/java/gradle.properties
+++ b/smart-contract/hyperledger-fabric/v2/java/gradle.properties
@@ -1,1 +1,2 @@
 openJMLVersion = 0.17.0-alpha-15
+withoutOpenJML = true


### PR DESCRIPTION
Add a withoutOpenJML Gradle property to be used during local development.